### PR TITLE
docs: add mcp-get installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ You can install this package using mcp-get:
 npx @michaellatman/mcp-get@latest install @llmindset/mcp-hfspace
 ```
 
+_Note - if you are using an old version of Windows PowerShell, you may need to run_ `Set-ExecutionPolicy Bypass -Scope Process` _before this command._
+
 ### Using Claude Desktop
 
 To use with Claude Desktop, add the server config:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ Private Spaces are supported with a HuggingFace token. The Token is used to down
 
 ## Installation
 
+### Using mcp-get
+
+You can install this package using mcp-get:
+
+```bash
+npx @michaellatman/mcp-get@latest install @llmindset/mcp-hfspace
+```
+
+### Using Claude Desktop
+
 To use with Claude Desktop, add the server config:
 
 On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`


### PR DESCRIPTION
Add installation instructions for using mcp-get package manager to install @llmindset/mcp-hfspace.

This PR adds a new section in the Installation documentation that shows users how to install the package using mcp-get, making it easier for users to discover and install the package through the official package manager.