### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mcp-hfspace MCP Server 🤗
+[![smithery badge](https://smithery.ai/badge/@llmindset/mcp-hfspace)](https://smithery.ai/protocol/@llmindset/mcp-hfspace)
 
 Use NPX `@llmindset/mcp-hfspace` or download and build from here.
 
@@ -7,6 +8,14 @@ Connect to [Hugging Face Spaces](https://huggingface.co/spaces)  with minimal se
 By default, it connects to `evalstate/FLUX.1-schnell` providing Image Generation capabilities to Claude Desktop.
 
 ![Default Setup](./images/2024-12-09-flower.png)
+
+### Installing via Smithery
+
+To install mcp-hfspace for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@llmindset/mcp-hfspace):
+
+```bash
+npx @smithery/cli install @llmindset/mcp-hfspace --client claude
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@ By default, it connects to `evalstate/FLUX.1-schnell` providing Image Generation
 
 ![Default Setup](./images/2024-12-09-flower.png)
 
-### Installing via Smithery
-
-To install mcp-hfspace for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@llmindset/mcp-hfspace):
-
-```bash
-npx @smithery/cli install @llmindset/mcp-hfspace --client claude
-```
-
 ## Installation
+
+Recommend installation is using either mcp-get or Smithery - instructions below.
 
 ### Using mcp-get
 
@@ -28,6 +22,14 @@ npx @michaellatman/mcp-get@latest install @llmindset/mcp-hfspace
 ```
 
 _Note - if you are using an old version of Windows PowerShell, you may need to run_ `Set-ExecutionPolicy Bypass -Scope Process` _before this command._
+
+### Installing via Smithery
+
+To install mcp-hfspace for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@llmindset/mcp-hfspace):
+
+```bash
+npx @smithery/cli install @llmindset/mcp-hfspace --client claude
+```
 
 ### Basic setup
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install mcp-hfspace for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.